### PR TITLE
Adding a github CI test runner workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,31 @@
+name: Build and Test
+on: push
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Check Format
+        run: cargo fmt --all -- --check
+      - name: Build the library
+        run: cargo build --locked
+      - name: Run standard test suite
+        run: cargo test
+      - name: Run tests under shuttle
+        run: cargo test --features "_shuttle" --lib


### PR DESCRIPTION
This is a standalone pull request to add automated cargo build / test runs to all commits. Without the changes from this pull request https://github.com/AmitPr/take-once/pull/1 , this action will fail (since there were existing doctest failures).

I ran this action in a separate branch with those changes here: https://github.com/chotchki/take-once/actions/runs/17251462079 to show it worked fine.